### PR TITLE
移除htmlrender的require

### DIFF
--- a/nonebot_plugin_logo/data_source.py
+++ b/nonebot_plugin_logo/data_source.py
@@ -6,9 +6,6 @@ from pathlib import Path
 from dataclasses import dataclass
 from typing import List, Tuple, Union, Protocol
 
-from nonebot import require
-
-require("nonebot_plugin_htmlrender")
 from nonebot_plugin_htmlrender import get_new_page, html_to_pic
 
 


### PR DESCRIPTION
htmlrender可以不用require导入，如果用require会与我安装的其他插件产生冲突